### PR TITLE
CMake fixes for macOS

### DIFF
--- a/cmake/modules/FindChromaprint.cmake
+++ b/cmake/modules/FindChromaprint.cmake
@@ -1,11 +1,11 @@
 include(FindPackageHandleStandardArgs)
 
-if (NOT WIN32)
+if (NOT WIN32 AND NOT APPLE)
   find_package(PkgConfig)
   if (PKG_CONFIG_FOUND)
     pkg_check_modules(CHROMAPRINT libchromaprint)
   endif ()
-endif (NOT WIN32)
+endif ()
 
 if ( NOT CHROMAPRINT_FOUND )
   find_path(CHROMAPRINT_INCLUDE_DIRS NAMES chromaprint.h)

--- a/cmake/modules/FindSampleRate.cmake
+++ b/cmake/modules/FindSampleRate.cmake
@@ -1,11 +1,11 @@
 include(FindPackageHandleStandardArgs)
 
-if (NOT WIN32)
+if (NOT WIN32 AND NOT APPLE)
   find_package(PkgConfig)
   if (PKG_CONFIG_FOUND)
     pkg_check_modules(SAMPLERATE samplerate)
   endif ()
-endif (NOT WIN32)
+endif ()
 
 if ( NOT SAMPLERATE_FOUND )
   find_path(SAMPLERATE_INCLUDE_DIRS NAMES samplerate.h)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,7 +21,7 @@ if(ESSENTIA_USE_FFMPEG)
 endif()
 
 if(ESSENTIA_USE_FFTW)
-  include_directories(${FFTW3_INCLUDE_DIRS})
+  include_directories(${FFTW3_INCLUDE_DIR})
   target_link_libraries(essentia PUBLIC ${FFTW3_LIBRARIES} ${FFTW3_FFTWF_LIBRARY})
   set(ENABLE_FFTW ON)
 elseif(ESSENTIA_USE_VDSP)


### PR DESCRIPTION
I tried to build with CMake on macOS using Ninja Multi-Config generator. 
All dependencies were installed using homebrew as documented [here](https://essentia.upf.edu/installing.html#installing-dependencies-on-macos).
For fftw3 the variable which holds the include directory had a typo.
For libchroma and libsamplerate the findpkg mechanism did not supply and adequate path to the libraries which is necessary afaik.

I hope this helps :)